### PR TITLE
Use "Discussions" instead of "Issues" as initial point of contact

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Bug Reports (and other issues)
+    url: https://github.com/pradyunsg/pip-resolver-benchmarks/discussions/categories/potential-issue
+    about: Possible bugs may be raised as a "Potential Issue" discussion.
+  - name: Feature Request / Enhancement
+    url: https://github.com/pradyunsg/pip-resolver-benchmarks/discussions/categories/ideas
+    about: Feature requests may be raised as an "Ideas" discussion.

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,0 +1,28 @@
+name: Trackable Change
+description: >-
+  Please only use this, if you've been advised to do so after discussion. Thanks! 🙏
+body:
+  - type: textarea
+    attributes:
+      label: What's happening?
+      description: A clear and concise description of the current behaviour.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Reproducer
+      description: Steps to reproduce the issue. Please attach screenshots as well.
+      value: |
+        1. Build Sphinx documentation at '...' (include build instructions)
+        2. Go to '...'
+        3. Click on '...'
+        4. Scroll down to '...'
+        5. See wrong thing.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expectation
+      description: A clear and concise description of what should've happened.
+    validations:
+      required: true


### PR DESCRIPTION
This makes it easier to use the issue tracker to track things that need doing.