### PR TITLE
Use a more appropriate-for-the-project placeholder

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -13,11 +13,9 @@ body:
       label: Reproducer
       description: Steps to reproduce the issue. Please attach screenshots as well.
       value: |
-        1. Build Sphinx documentation at '...' (include build instructions)
-        2. Go to '...'
-        3. Click on '...'
-        4. Scroll down to '...'
-        5. See wrong thing.
+        1. Run `nox -s fetch -- sampleproject`.
+        1. ???
+        1. Profit.
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
The old content was a thing that slipped through due to copy-paste.