### PR TITLE
Catch invalid sdist names and skip

### DIFF
--- a/src/fetch-info.py
+++ b/src/fetch-info.py
@@ -43,6 +43,7 @@ from packaging.utils import (
     canonicalize_name,
     parse_sdist_filename,
     parse_wheel_filename,
+    InvalidSdistFilename
 )
 from packaging.version import Version
 from rich.live import Live
@@ -284,7 +285,13 @@ class PackageIndex:
                     sdist_name = project_name
                     version = filename[len(project_name) + 1 : -len(".tar.gz")]
                 else:
-                    sdist_name, version_t = parse_sdist_filename(filename)
+                    try:
+                        sdist_name, version_t = parse_sdist_filename(filename)
+                    except InvalidSdistFilename:
+                        rich.print(
+                            f"Failed to parse sdist name from file: {filename}"
+                        )
+                        continue
                     version = str(version_t)
                 dist_details[version].append(((sdist_name, version), url))
 


### PR DESCRIPTION
When you allow sdists for projects which have invalid sdist names the fetch proecess current fail throwing an exception trying to parse the sdist name