### PR TITLE
Skip invalid wheels

### DIFF
--- a/src/common/hacks.py
+++ b/src/common/hacks.py
@@ -1,6 +1,6 @@
 """This module is where I put things that I'm not proud of."""
 
-from pip._internal.exceptions import UnsupportedWheel
+from pip._internal.exceptions import UnsupportedWheel, InvalidWheel
 from pip._internal.network.lazy_wheel import dist_from_wheel_url
 from pip._internal.network.session import PipSession
 
@@ -21,6 +21,6 @@ def metadata_from_wheel_url(
     session = create_session()
     try:
         dist = dist_from_wheel_url(name=project_name, url=wheel_url, session=session)
-    except UnsupportedWheel:
+    except (UnsupportedWheel, InvalidWheel):
         return None
     return dist.read_text("METADATA")


### PR DESCRIPTION
I was trying to build a scenario today and I got this error:

```
pip._internal.exceptions.InvalidWheel: Wheel 'wcwidth' located at https://files.pythonhosted.org/packages/6c/a6/cdb485093ad4017d874d7a2e6a736d02720258f57876548eea2bf04c76f0/wcwidth-0.2.1-py2.py3-none-any.whl is invalid (wcwidth has an invalid wheel, wcwidth has an invalid wheel, multiple .dist-info directories found: wcwidth-0.2.1.dist-info, wcwidth-0.2.0.dist-info)
```

If unsupported wheels are skipped it makes sense to skip invalid wheels