### PR TITLE
Use older style type annotations for old versions of Python

### DIFF
--- a/src/common/hacks.py
+++ b/src/common/hacks.py
@@ -1,5 +1,7 @@
 """This module is where I put things that I'm not proud of."""
 
+from typing import Optional
+
 from pip._internal.exceptions import UnsupportedWheel
 from pip._internal.network.lazy_wheel import dist_from_wheel_url
 from pip._internal.network.session import PipSession
@@ -13,7 +15,7 @@ def create_session() -> PipSession:
 
 def metadata_from_wheel_url(
     project_name: str, wheel_url: str, session: PipSession
-) -> str | None:
+) -> Optional[str]:
     """Get metadata from a wheel URL.
 
     I could re-implement this myself, but... this is easier.

--- a/src/common/model.py
+++ b/src/common/model.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import datetime
 import re
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Optional
 
 import rich
 from packaging.utils import canonicalize_version, is_normalized_name
@@ -20,13 +20,13 @@ WHEELHOUSE_DIR = _repo_root / "wheelhouse.ignore"
 
 class DistributionInfo(BaseModel):
     depends_by_extra: dict[str, list[str]]
-    requires_python: str | None = None
+    requires_python: Optional[str] = None
 
     @field_validator("depends_by_extra", mode="after")
     @classmethod
     def ensure_no_empty_extras(
-        cls, v: dict[str | None, list[str]]
-    ) -> dict[str | None, list[str]]:
+        cls, v: dict[Optional[str], list[str]]
+    ) -> dict[Optional[str], list[str]]:
         for depends in v.values():
             for dep in depends:
                 assert ";" not in dep


### PR DESCRIPTION
I was building a scenario today that required Python 3.9.

Because Pydantic inspects annotatons at runtime it can not use syntax that was introduced in newer versions of Python, so even switching to `from __future__ import annotations` does not help.

This PR allows Pydantic to run on at least Python 3.9. Although to run on Python 3.9 you still need to manually create a `requirements-3.9.txt` and edit the noxfile.